### PR TITLE
Filler error due to Amq connection reset

### DIFF
--- a/src/connections/amq.js
+++ b/src/connections/amq.js
@@ -28,7 +28,7 @@ class Amq {
             try {
                 await this.init();
                 if (this.reconnectHandler) {
-                    this.reconnectHandler();
+                    await this.reconnectHandler();
                 }
             }
             catch (e){
@@ -76,7 +76,7 @@ class Amq {
                 log_fn('Connection Error', {e:err});
                 this.initialized = false;
                 if (this.disconnectHandler) {
-                    this.disconnectHandler();
+                    await this.disconnectHandler();
                 }
                 this.reconnect();
             }
@@ -85,7 +85,7 @@ class Amq {
             this.logger.warn('Connection closed');
             this.initialized = false;
             if (this.disconnectHandler) {
-                    this.disconnectHandler();
+                    await this.disconnectHandler();
                 }
             this.reconnect();
         });

--- a/src/connections/amq.js
+++ b/src/connections/amq.js
@@ -69,7 +69,7 @@ class Amq {
         this.initialized = true;
         this.connection_errors = 0;
 
-        conn.on('error', (err) => {
+        conn.on('error', async (err) => {
             if (err.message !== 'Connection closing') {
                 const log_fn = (this.connection_errors > this.max_connection_errors)?this.logger.error:this.logger.warn;
 
@@ -81,7 +81,7 @@ class Amq {
                 this.reconnect();
             }
         });
-        conn.on('close', () => {
+        conn.on('close', async () => {
             this.logger.warn('Connection closed');
             this.initialized = false;
             if (this.disconnectHandler) {

--- a/src/connections/amq.js
+++ b/src/connections/amq.js
@@ -8,16 +8,28 @@ class Amq {
         this.listeners = [];
         this.connection_errors = 0;
         this.max_connection_errors = 5;
-
         this.logger = require('./logger')('eosdac-amq', config.logger);
+        this.reconnectHandler;
+        this.disconnectHandler;
     }
 
-    async reconnect(){
-        if (this.listeners.length && !this.initialized){
+    onDisconnected(handler) {
+        this.disconnectHandler = handler;
+    }
+
+    onReconnected(handler) {
+        this.reconnectHandler = handler;
+    }
+
+    async reconnect() {
+        if (!this.initialized){
             this.logger.info(`Reloading connection with listeners`);
 
             try {
                 await this.init();
+                if (this.reconnectHandler) {
+                    this.reconnectHandler();
+                }
             }
             catch (e){
                 this.connection_errors++;
@@ -31,7 +43,7 @@ class Amq {
                 return;
             }
 
-            this.logger.info(`Adding listeners`);
+            this.logger.info(`Adding ${this.listeners.length} listeners`);
             this.listeners.forEach(({queue_name, cb}) => {
                 this.listen(queue_name, cb);
             });
@@ -63,28 +75,32 @@ class Amq {
 
                 log_fn('Connection Error', {e:err});
                 this.initialized = false;
+                if (this.disconnectHandler) {
+                    this.disconnectHandler();
+                }
                 this.reconnect();
             }
         });
         conn.on('close', () => {
             this.logger.warn('Connection closed');
             this.initialized = false;
+            if (this.disconnectHandler) {
+                    this.disconnectHandler();
+                }
             this.reconnect();
         });
     }
 
     async send(queue_name, msg) {
-        if (!Buffer.isBuffer(msg)) {
-            msg = Buffer.from(msg)
+        if (this.initialized){
+            if (!Buffer.isBuffer(msg)) {
+                msg = Buffer.from(msg)
+            }
+            this.logger.info(`Message sent to queue ${queue_name}`);
+            return this.channel.sendToQueue(queue_name, msg)
+        } else {
+            this.logger.error('Cannot perform operation "send", AMQ is not connected!');
         }
-
-        if (!this.initialized){
-            await this.init();
-        }
-
-        this.logger.info(`Message sent to queue ${queue_name}`);
-
-        return this.channel.sendToQueue(queue_name, msg)
     }
     //
     // async publish(key, data, delay_ms){
@@ -102,39 +118,40 @@ class Amq {
     // }
 
     async listen(queue_name, cb) {
-        if (!this.initialized){
-            await this.init();
+        if (this.initialized){
+            this.channel.prefetch(1);
+            // await this.channel.assertQueue(queue_name, {durable: true})
+            this.listeners.push({queue_name, cb});
+            this.channel.consume(queue_name, cb, {noAck: false})
+        } else {
+            this.logger.error('Cannot perform operation "listen", AMQ is not connected!');
         }
-
-        this.channel.prefetch(1);
-        // await this.channel.assertQueue(queue_name, {durable: true})
-        this.listeners.push({queue_name, cb});
-
-        this.channel.consume(queue_name, cb, {noAck: false})
     }
 
     async ack(job) {
-        if (!this.initialized){
-            await this.init();
-        }
-        try {
-            return this.channel.ack(job);
-        }
-        catch (e){
-            this.logger.error(`Failed to ack job`, e);
-            // failure to ack isnt a problem, all jobs are idempotent
+        if (this.initialized){
+            try {
+                return this.channel.ack(job);
+            }
+            catch (e){
+                this.logger.error(`Failed to ack job`, e);
+                // failure to ack isnt a problem, all jobs are idempotent
+            }
+        } else {
+            this.logger.error('Cannot perform operation "ack", AMQ is not connected!');
         }
     }
 
     async reject(job) {
-        if (!this.initialized){
-            await this.init();
-        }
-        try {
-            return this.channel.reject(job, true);
-        }
-        catch (e){
-            this.logger.error(`Failed to reject job`);
+        if (this.initialized) {  
+            try {
+                return this.channel.reject(job, true);
+            }
+            catch (e){
+                this.logger.error(`Failed to reject job`);
+            }
+        } else {
+            this.logger.error('Cannot perform operation "reject", AMQ is not connected!');
         }
     }
 }

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -20,20 +20,11 @@ const signatureProvider = null;
 
 
 const {ActionHandler, TraceHandler, DeltaHandler, BlockHandler} = require('./handlers');
-const StateReceiver = require('@eosdacio/eosio-statereceiver');
+// const StateReceiver = require('@eosdacio/eosio-statereceiver');
+const StateReceiver = require('./state-receiver');
 
 // var access = fs.createWriteStream('filler.log')
 // process.stdout.write = process.stderr.write = access.write.bind(access)
-
-const disposeHandlers = (stateReceiver) => {
-    stateReceiver.trace_handlers = [];
-    stateReceiver.delta_handlers = [];
-    stateReceiver.done_handlers = [];
-    stateReceiver.progress_handlers = [];
-    stateReceiver.connected_handlers = [];
-    stateReceiver.block_handlers = [];
-    stateReceiver.fork_handlers = [];
-}
 
 class FillManager {
     constructor({startBlock = 0, endBlock = 0xffffffff, config = '', irreversibleOnly = false, replay = false, test = 0, processOnly = false}) {
@@ -197,8 +188,7 @@ class FillManager {
 
             this.logger.info(`No replay, starting from block ${start_block}, LIB is ${lib}`);
             this.amq.onDisconnected(() => {
-                disposeHandlers(this.br);
-                this.br.connection.ws.terminate();
+                this.br.stop(true);
             });
 
             this.amq.onReconnected(() => {

--- a/src/handlers/delta-handler.js
+++ b/src/handlers/delta-handler.js
@@ -11,7 +11,7 @@ const Int64 = require('int64-buffer').Int64BE;
 
 class DeltaHandler {
     constructor({queue, config, dac_directory, logger}) {
-        this.queue = queue;
+        this.amq = queue;
         this.config = config;
         this.dac_directory = dac_directory;
         this.logger = logger;
@@ -27,7 +27,9 @@ class DeltaHandler {
         });
 
         this.connectDb();
-        this.connectAmq();
+        if (!this.amq) {
+            this.connectAmq();
+        }
 
     }
 
@@ -187,9 +189,11 @@ class DeltaHandler {
             const block_buffer = new Int64(block_num).toBuffer();
             const present_buffer = Buffer.from([row.present]);
             // this.logger.info(`Publishing ${name}`)
+            if (this.amq) {
             this.amq.send(name, Buffer.concat([block_buffer, present_buffer, timestamp_buffer, Buffer.from(row.data)]))
                 .then(resolve)
                 .catch(reject)
+            }
         })
 
     }

--- a/src/state-receiver/connection.js
+++ b/src/state-receiver/connection.js
@@ -1,0 +1,251 @@
+const WebSocket = require('ws');
+const { Serialize } = require('eosjs');
+const { TextDecoder, TextEncoder } = require('text-encoding');
+const zlib = require('zlib');
+
+class Connection {
+    constructor({ socketAddresses, socketAddress, receivedAbi, receivedBlock  }) {
+        this.receivedAbi = receivedAbi;
+        this.receivedBlock = receivedBlock;
+        this.socketAddresses = socketAddresses;
+        if (typeof socketAddress == 'string' && !(socketAddresses && socketAddresses.length)){
+            this.socketAddresses = [socketAddress]
+        }
+
+        this.abi = null;
+        this.types = null;
+        this.tables = new Map;
+        this.blocksQueue = [];
+        this.inProcessBlocks = false;
+        this.socket_index = 0;
+        this.currentArgs = null;
+        this.connected = false;
+        this.connecting = false;
+        this.connectionRetries = 0;
+        this.maxConnectionRetries = 100;
+
+        this.connect(this.socketAddresses[this.socket_index]);
+    }
+
+    connect(endpoint){
+        if (!this.connected && !this.connecting){
+            console.log(`Websocket connecting to ${endpoint}`);
+
+            this.connecting = true;
+
+            this.ws = new WebSocket(endpoint, { perMessageDeflate: false });
+            this.ws.on('open', () => this.onConnect());
+            this.ws.on('message', data => this.onMessage(data));
+            // this.ws.on('error', () => this.onError());
+            this.ws.on('close', (e) => this.onClose(e));
+            this.ws.on('error', (e) => {console.error(`Websocket error`, e)});
+            // this.ws.on('close', (e) => {console.error(`Websocket close`, e)});
+        }
+    }
+
+    disconnect(force) {
+        if (force) {
+            console.log(`Force closing connection`);
+            this.ws.removeAllListeners();
+            this.ws.terminate();
+        } else {
+            console.log(`Closing connection`);
+            this.ws.close();
+        }
+    }
+
+    reconnect(){
+        if (this.connectionRetries > this.maxConnectionRetries){
+            console.error(`Exceeded max reconnection attempts of ${this.maxConnectionRetries}`);
+            return;
+        }
+        else {
+            const endpoint = this.nextEndpoint();
+            console.log(`Reconnecting to ${endpoint}...`);
+            const timeout = Math.pow(2, this.connectionRetries/5) * 1000;
+            console.log(`Retrying with delay of ${timeout / 1000}s`);
+            setTimeout(() => {
+                this.connect(endpoint);
+            }, timeout);
+            this.connectionRetries++;
+        }
+    }
+
+    nextEndpoint(){
+        let next_index = ++this.socket_index;
+
+        if (next_index >= this.socketAddresses.length){
+            next_index = 0;
+        }
+        this.socket_index = next_index;
+
+        return this.socketAddresses[this.socket_index];
+    }
+
+    serialize(type, value) {
+        const buffer = new Serialize.SerialBuffer({ textEncoder: new TextEncoder, textDecoder: new TextDecoder });
+        Serialize.getType(this.types, type).serialize(buffer, value);
+        return buffer.asUint8Array();
+    }
+
+    deserialize(type, array) {
+        const buffer = new Serialize.SerialBuffer({ textEncoder: new TextEncoder, textDecoder: new TextDecoder, array });
+        let result = Serialize.getType(this.types, type).deserialize(buffer, new Serialize.SerializerState({ bytesAsUint8Array: true }));
+        if (buffer.readPos != array.length)
+            throw new Error('oops: ' + type); // todo: remove check
+        // {
+        //     console.log(result.actions[0].authorization[0].actor);
+        //     //console.log('oops: ' + type);
+        // }
+        return result;
+    }
+
+    toJsonUnpackTransaction(x) {
+        return JSON.stringify(x, (k, v) => {
+            if (k === 'trx' && Array.isArray(v) && v[0] === 'packed_transaction') {
+                const pt = v[1];
+                let packed_trx = pt.packed_trx;
+                console.log(`Compression is ${pt.compression}`);
+                if (pt.compression === 0)
+                    packed_trx = this.deserialize('transaction', packed_trx);
+                else if (pt.compression === 1)
+                    packed_trx = this.deserialize('transaction', zlib.unzipSync(packed_trx));
+                return { ...pt, packed_trx };
+            }
+            if (k === 'packed_trx' && v instanceof Uint8Array)
+                return this.deserialize('transaction', v);
+            if (v instanceof Uint8Array)
+                return `(${v.length} bytes)`;
+            return v;
+        }, 4)
+    }
+
+    send(request) {
+        this.ws.send(this.serialize('request', request));
+    }
+
+    onConnect(){
+        this.connected = true;
+        this.connecting = false;
+        this.connectionRetries = 0;
+    }
+
+    onMessage(data) {
+        try {
+            if (!this.abi) {
+                console.log('receiving abi')
+                this.rawabi = data;
+                this.abi = JSON.parse(data);
+                this.types = Serialize.getTypesFromAbi(Serialize.createInitialTypes(), this.abi);
+                for (const table of this.abi.tables)
+                    this.tables.set(table.name, table.type);
+                if (this.receivedAbi)
+                    this.receivedAbi();
+            } else {
+                const [type, response] = this.deserialize('result', data);
+                this[type](response);
+            }
+        } catch (e) {
+            console.log(e);
+            process.exit(1);
+        }
+    }
+
+    onClose(code) {
+        console.error(`Websocket disconnected from ${this.socketAddresses[this.socket_index]} with code ${code}`);
+        // this.ws.terminate();
+        this.abi = null;
+        this.types = null;
+        this.tables = new Map;
+        this.blocksQueue = [];
+        this.inProcessBlocks = false;
+        this.connected = false;
+        this.connecting = false;
+
+        if (code !== 1000){
+            // 1000 = closed by me normally
+            this.reconnect();
+        }
+
+    }
+
+    onOpen(){
+        this.requestBlocks(this.currentArgs)
+    }
+
+    requestStatus() {
+        this.send(['get_status_request_v0', {}]);
+    }
+
+    requestBlocks(requestArgs) {
+        if (!this.currentArgs){
+            this.currentArgs = {
+                start_block_num: 0,
+                end_block_num: 0xffffffff,
+                max_messages_in_flight: 5,
+                have_positions: [],
+                irreversible_only: false,
+                fetch_block: false,
+                fetch_traces: false,
+                fetch_deltas: false,
+                ...requestArgs
+            };
+        }
+        this.send(['get_blocks_request_v0', this.currentArgs]);
+    }
+
+    get_status_result_v0(response) {
+        console.log(response);
+    }
+
+    get_blocks_result_v0(response) {
+        this.blocksQueue.push(response);
+        this.processBlocks();
+    }
+
+    async processBlocks() {
+        if (this.inProcessBlocks)
+            return;
+        this.inProcessBlocks = true;
+        while (this.blocksQueue.length) {
+            let response = this.blocksQueue.shift();
+            if (response.this_block){
+                let block_num = response.this_block.block_num;
+                this.currentArgs.start_block_num = block_num - 50; // replay 25 seconds
+            }
+            this.send(['get_blocks_ack_request_v0', { num_messages: 1 }]);
+            let block, traces = [], deltas = [];
+            if (this.currentArgs.fetch_block && response.block && response.block.length)
+                block = this.deserialize('signed_block', response.block);
+            if (this.currentArgs.fetch_traces && response.traces && response.traces.length)
+                traces = this.deserialize('transaction_trace[]', response.traces);
+            if (this.currentArgs.fetch_deltas && response.deltas && response.deltas.length)
+                deltas = this.deserialize('table_delta[]', response.deltas);
+            await this.receivedBlock(response, block, traces, deltas);
+        }
+        this.inProcessBlocks = false;
+    }
+
+    forEachRow(delta, f) {
+        const type = this.tables.get(delta.name);
+        for (let row of delta.rows) {
+            let data;
+            try {
+                data = this.deserialize(type, row.data);
+            } catch (e) {
+                console.error(e);
+            }
+            if (data)
+                f(row.present, data[1]);
+        }
+    }
+
+    dumpDelta(delta, extra) {
+        this.forEachRow(delta, (present, data) => {
+            console.log(this.toJsonUnpackTransaction({ ...extra, present, data }));
+        });
+    }
+} // Connection
+
+
+module.exports = {Connection}

--- a/src/state-receiver/index.js
+++ b/src/state-receiver/index.js
@@ -1,0 +1,247 @@
+const { Connection } = require("./connection")
+
+
+class StateReceiver {
+    /* mode 0 = serial, 1 = parallel */
+    constructor({ startBlock = 0, endBlock = 0xffffffff, config, mode = 0, irreversibleOnly = false }){
+        this.trace_handlers = []
+        this.delta_handlers = []
+        this.done_handlers = []
+        this.progress_handlers = []
+        this.connected_handlers = []
+        this.block_handlers = []
+        this.fork_handlers = []
+        this.irreversible_only = irreversibleOnly
+
+        // console.log(config)
+
+        this.config = config
+        this.mode = mode
+
+        this.start_block = startBlock
+        this.end_block = endBlock
+        this.current_block = -1
+        this.complete = true
+
+        const mode_str = (mode==0)?'serial':'parallel';
+
+        console.log(`Created StateReceiver, Start : ${startBlock}, End : ${endBlock}, Mode : ${mode_str}`);
+
+    }
+
+    parseDate (fullStr) {
+        const [fullDate] = fullStr.split('.')
+        const [dateStr, timeStr] = fullDate.split('T')
+        const [year, month, day] = dateStr.split('-')
+        const [hourStr, minuteStr, secondStr] = timeStr.split(':')
+
+        const dt = new Date()
+        dt.setUTCFullYear(year)
+        dt.setUTCMonth(month - 1)
+        dt.setUTCDate(day)
+        dt.setUTCHours(hourStr)
+        dt.setUTCMinutes(minuteStr)
+        dt.setUTCSeconds(secondStr)
+
+        return dt.getTime()
+    }
+
+    registerBlockHandler(h){
+        this.block_handlers.push(h)
+    }
+
+    registerDoneHandler(h){
+        this.done_handlers.push(h)
+    }
+
+    registerTraceHandler(h){
+        this.trace_handlers.push(h)
+    }
+
+    registerDeltaHandler(h){
+        this.delta_handlers.push(h)
+    }
+
+    registerProgressHandler(h){
+        this.progress_handlers.push(h)
+    }
+
+    registerForkHandler(h){
+        this.fork_handlers.push(h)
+    }
+
+    registerConnectedHandler(h){
+        this.connected_handlers.push(h)
+    }
+
+    status(){
+        const start = this.start_block
+        const end = this.end_block
+        const current = this.current_block
+
+        return {start, end, current}
+    }
+
+    async stop(force) {
+        this.complete = false;
+        this.trace_handlers = [];
+        this.delta_handlers = [];
+        this.block_handlers = [];
+        this.connection.disconnect(force);
+        
+    }
+
+    async start(){
+        this.complete = false
+
+        this.connection = new Connection({
+            socketAddress: this.config.eos.wsEndpoint,
+            socketAddresses: this.config.eos.wsEndpoints,
+            receivedAbi: (() => {
+                this.requestBlocks()
+
+                this.connected_handlers.forEach(((handler) => {
+                    handler(this.connection)
+                }).bind(this))
+            }).bind(this),
+            receivedBlock: this.receivedBlock.bind(this)
+        });
+    }
+
+    async restart(startBlock, endBlock){
+        this.complete = false
+
+        this.start_block = startBlock
+        this.end_block = endBlock
+
+        this.connection = new Connection({
+            socketAddress: this.config.eos.wsEndpoint,
+            socketAddresses: this.config.eos.wsEndpoints,
+            receivedAbi: (() => {
+                this.requestBlocks()
+
+                this.connected_handlers.forEach(((handler) => {
+                    handler(this.connection)
+                }).bind(this))
+            }).bind(this),
+            receivedBlock: this.receivedBlock.bind(this)
+        });
+        // await this.requestBlocks()
+    }
+
+    destroy(){
+        console.log(`Destroying (TODO)`)
+    }
+
+    async requestBlocks(){
+        try {
+            this.current_block = 0;
+
+            await this.connection.requestBlocks({
+                irreversible_only: this.irreversible_only,
+                start_block_num: parseInt(this.start_block),
+                end_block_num: parseInt(this.end_block),
+                have_positions:[],
+                fetch_block: true,
+                fetch_traces: (this.trace_handlers.length > 0),
+                fetch_deltas: (this.delta_handlers.length > 0),
+            });
+        } catch (e) {
+            console.error(e);
+            process.exit(1);
+        }
+    }
+
+    async handleFork(block_num){
+        console.log('FORK HANDLERS', this.fork_handlers.length)
+        this.fork_handlers.forEach((h) => {
+            h(block_num)
+        })
+    }
+
+    async receivedBlock(response, block, traces, deltas) {
+        if (!response.this_block)
+            return;
+        let block_num = response.this_block.block_num;
+        //console.log(response.this_block)
+        // console.log(`Received block ${block_num}`)
+
+        if ( this.mode === 0 && block_num <= this.current_block ){
+            console.log(`Detected fork in serial mode: current:${block_num} <= head:${this.current_block}`)
+            await this.handleFork(block_num)
+        }
+
+        this.complete = false
+
+        this.current_block = block_num
+
+        if (!(block_num % 1000)){
+            console.info(`StateReceiver : received block ${block_num}`);
+            let {start, end, current} = this.status()
+            console.info(`Start: ${start}, End: ${end}, Current: ${current}`)
+
+            // this.connection.requestStatus()
+            // this.queue.inactiveCount((err, total) => {
+            //     console.info("redis queue length " + total)
+            // })
+        }
+
+        let block_timestamp = null;
+        if (block){
+            block_timestamp = new Date(this.parseDate(block.timestamp.replace(['.000', '.500'], 'Z')));
+        }
+        else {
+            block_timestamp = new Date();
+        }
+
+        if (deltas && deltas.length){
+            this.delta_handlers.forEach(((handler) => {
+                if (this.mode === 0){
+                    handler.processDelta(block_num, deltas, this.connection.types, block_timestamp)
+                }
+                else {
+                    handler.queueDelta(block_num, deltas, this.connection.types, block_timestamp)
+                }
+            }).bind(this))
+        }
+
+        if (traces){
+            this.trace_handlers.forEach((handler) => {
+                if (this.mode === 0){
+                    handler.processTrace(block_num, traces, block_timestamp)
+                }
+                else {
+                    handler.queueTrace(block_num, traces, block_timestamp)
+                }
+            })
+        }
+        if (block){
+            this.block_handlers.forEach((handler) => {
+                if (this.mode === 0){
+                    handler.processBlock(block_num, block)
+                }
+                else {
+                    handler.queueBlock(block_num, block)
+                }
+            })
+        }
+
+        if (this.current_block === this.end_block -1){
+            console.log(`State Handler complete!`)
+            this.complete = true
+            this.done_handlers.forEach((handler) => {
+                handler()
+            })
+            this.connection.disconnect()
+        }
+
+        this.progress_handlers.forEach((handler) => {
+            handler(100 * ((block_num - this.start_block) / this.end_block))
+        })
+
+
+    } // receivedBlock
+}
+
+
+module.exports = StateReceiver


### PR DESCRIPTION
This PR contains a fix for the problem that the 'filler' process crashes when AMQ loses connection.
There are several reasons for the problem ... the first is that AMQ does not inform the environment about the lack of connection to the server.
Each command was unnecessarily preceded by an init method which was not in the try catch block which caused an exception.
Whenever the connection is lost, AMQ tries to reestablish it and all processes should stop until then.

In this hot-fix no method (send, listen, ack...) is invoked if AMQ is unavailable, instead a "no connection" message is logged.

The next thing is that we have a lot of nested code in which we pass instances of AMQ and still do nothing in case of connection changes. I added simple callbacks (onDisconnect and onReconnect) to handle the AMQ status change in some way.

The problem is also StateReceiver and Connection which use AMQ and WebSocket in a chaotic and poorly controlled way. Despite connection issues on AMQ, the messages were still pushed. To avoid this I had to terminate the web socket connection in an ugly way (we have no access to do it softly - because it's external package) and dispose the stateReceiver handlers. When the AMQ connection is restored, the handlers and the stateReceiver / webSocket itself are recreated.

Please check if nothing breaks