### PR TITLE
Fix websocket after close

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,7 +23,7 @@ services:
 
   filler:
     command:
-      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler -r']
+      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler']
     depends_on:
       - queue
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -23,7 +23,7 @@ services:
 
   filler:
     command:
-      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler']
+      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler -r']
     depends_on:
       - queue
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,12 +66,16 @@ services:
       CONFIG: '${CONFIG}'
       FILLER_FLAGS: '-r'
     restart: on-failure
+   
+    command:
+      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler -r -s 105376981']
     volumes:
       - eosdac-api:/tmp/
 
   ws:
     image: ghcr.io/alien-worlds/eosdac_ws
     platform: linux/amd64
+    
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,6 @@ services:
       FILLER_FLAGS: '-r'
     restart: on-failure
    
-    command:
-      ['sh', '-c', 'scripts/wq.sh && flags="${FILLER_FLAGS}" yarn filler -r -s 105376981']
     volumes:
       - eosdac-api:/tmp/
 

--- a/src/connections/logger.js
+++ b/src/connections/logger.js
@@ -11,6 +11,18 @@ const logger = ((service='undefined-service', config) => {
             new winston.transports.Console({
                 format: winston.format.simple(),
                 colorize: true
+            }),
+            new winston.transports.File({
+                filename: `logs/${service}_debug.log`,
+                level: 'debug'
+            }),
+            new winston.transports.File({
+                filename: `logs/${service}_info.log`,
+                level: 'info'
+            }),
+            new winston.transports.File({
+                filename: `logs/${service}_error.log`,
+                level: 'error'
             })
         ]
     });

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -59,6 +59,7 @@ class FillManager {
         if (start_block === -1) {
             start_block = await getRestartBlock();
         }
+        let end_block = this.end_block;
 
         // If replay is set then we start from block 0 in parallel and then start a serial handler from lib onwards
         // Otherwise we start from this.start_block in serial
@@ -201,7 +202,7 @@ class FillManager {
 
             const block_handler = new BlockHandler({config: this.config});
 
-            this.br = new StateReceiver({startBlock: start_block, mode: 0, config: this.config});
+            this.br = new StateReceiver({startBlock: start_block, endBlock: end_block, mode: 0, config: this.config});
             this.br.registerTraceHandler(trace_handler);
             this.br.registerDeltaHandler(delta_handler);
             this.br.registerBlockHandler(block_handler);
@@ -287,7 +288,8 @@ commander
     .version('0.1', '-v, --version')
     .option('-s, --start-block <start-block>', 'Start at this block', -1)
     .option('-t, --test <block>', 'Test mode, specify a single block to pull and process', parseInt, 0)
-    .option('-e, --end-block <end-block>', 'End block (exclusive)', parseInt, 0xffffffff)
+    //.option('-e, --end-block <end-block>', 'End block (exclusive)', parseInt, 0xffffffff)
+    .option('-e, --end-block <end-block>', 'End block (exclusive)', 0xffffffff)
     .option('-r, --replay', 'Force replay (ignore head block)', false)
     .option('-p, --process-only', 'Only process queue items (do not populate)', false)
     .parse(process.argv);

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -22,12 +22,13 @@ const signatureProvider = null;
 const {ActionHandler, TraceHandler, DeltaHandler, BlockHandler} = require('./handlers');
 // const StateReceiver = require('@eosdacio/eosio-statereceiver');
 const StateReceiver = require('./state-receiver');
+const { exit } = require('process');
 
 // var access = fs.createWriteStream('filler.log')
 // process.stdout.write = process.stderr.write = access.write.bind(access)
 
 class FillManager {
-    constructor({startBlock = 0, endBlock = 0xffffffff, config = '', irreversibleOnly = false, replay = false, test = 0, processOnly = false}) {
+    constructor({startBlock = 0, endBlock = 0xffffffff, config = '', irreversibleOnly = false, replay = false, test = 0, processOnly = false, populateOnly = false}) {
         this.config = loadConfig();
         this.start_block = startBlock;
         this.end_block = endBlock;
@@ -36,6 +37,7 @@ class FillManager {
         this.test_block = test;
         this.job = null;
         this.process_only = processOnly;
+        this.populate_only = populateOnly;
 
         console.log(`Loading config ${this.config.name}.config.js`);
 
@@ -132,6 +134,8 @@ class FillManager {
 
                 this.logger.info(`Queued ${number_jobs} jobs`);
 
+                if (this.populate_only) return exit(0);
+                
                 for (let i = 0; i < this.config.fillClusterSize; i++) {
                     cluster.fork();
                 }
@@ -143,6 +147,7 @@ class FillManager {
                 // this.br.start()
             } else {
                 //queue.process('block_range', 1, this.processBlockRange.bind(this))
+                
                 this.logger.info(`Listening to queue for block_range`);
                 this.amq.listen('block_range', this.processBlockRange.bind(this));
             }
@@ -177,6 +182,7 @@ class FillManager {
                     cluster.fork();
                 }
             } else {
+
                 this.logger.info(`Listening to queue for block_range ONLY`);
                 this.amq.listen('block_range', this.processBlockRange.bind(this));
             }
@@ -292,6 +298,7 @@ commander
     .option('-e, --end-block <end-block>', 'End block (exclusive)', 0xffffffff)
     .option('-r, --replay', 'Force replay (ignore head block)', false)
     .option('-p, --process-only', 'Only process queue items (do not populate)', false)
+    .option('-l, --populate-only', 'Only queue items (do not process) (Use with -r only)', false)
     .parse(process.argv);
 
 

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -133,12 +133,11 @@ class FillManager {
                 }
 
                 this.logger.info(`Queued ${number_jobs} jobs`);
-
-                if (this.populate_only) return exit(0);
                 
                 for (let i = 0; i < this.config.fillClusterSize; i++) {
                     cluster.fork();
                 }
+                
 
                 // Start from current lib
                 // this.br = new StateReceiver({startBlock: lib, mode: 1, config: this.config});
@@ -147,9 +146,10 @@ class FillManager {
                 // this.br.start()
             } else {
                 //queue.process('block_range', 1, this.processBlockRange.bind(this))
-                
-                this.logger.info(`Listening to queue for block_range`);
-                this.amq.listen('block_range', this.processBlockRange.bind(this));
+                if (!this.populate_only) {
+                    this.logger.info(`Listening to queue for block_range`);
+                    this.amq.listen('block_range', this.processBlockRange.bind(this));
+                } 
             }
 
         } else if (this.test_block) {

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -104,7 +104,8 @@ class FillManager {
                     let from_buffer = new Int64BE(from).toBuffer();
                     let to_buffer = new Int64BE(to).toBuffer();
 
-                    this.amq.send('block_range', Buffer.concat([from_buffer, to_buffer]));
+                    let b = Buffer.concat([from_buffer, to_buffer]);
+                    this.amq.send('block_range', b);
                     number_jobs++;
 
                     if (to === lib) {

--- a/src/state-receiver/connection.js
+++ b/src/state-receiver/connection.js
@@ -242,7 +242,12 @@ class Connection {
       if (response.this_block) {
         let block_num = response.this_block.block_num;
         this.currentArgs.start_block_num = block_num - 50; // replay 25 seconds
+      } else {
+        this.logger.info("Stop processing blocks");
+        break;
       }
+
+
       this.send(["get_blocks_ack_request_v0", { num_messages: 1 }]);
       let block,
         traces = [],

--- a/src/state-receiver/connection.js
+++ b/src/state-receiver/connection.js
@@ -180,7 +180,7 @@ class Connection {
   }
 
   onClose(code) {
-    this.logger.error(
+    this.logger.info(
       `Websocket disconnected from ${
         this.socketAddresses[this.socket_index]
       } with code ${code}`

--- a/src/state-receiver/connection.js
+++ b/src/state-receiver/connection.js
@@ -1,251 +1,293 @@
-const WebSocket = require('ws');
-const { Serialize } = require('eosjs');
-const { TextDecoder, TextEncoder } = require('text-encoding');
-const zlib = require('zlib');
+const WebSocket = require("ws");
+const { Serialize } = require("eosjs");
+const { TextDecoder, TextEncoder } = require("text-encoding");
+const zlib = require("zlib");
 
 class Connection {
-    constructor({ socketAddresses, socketAddress, receivedAbi, receivedBlock  }) {
-        this.receivedAbi = receivedAbi;
-        this.receivedBlock = receivedBlock;
-        this.socketAddresses = socketAddresses;
-        if (typeof socketAddress == 'string' && !(socketAddresses && socketAddresses.length)){
-            this.socketAddresses = [socketAddress]
+  constructor({ socketAddresses, socketAddress, receivedAbi, receivedBlock, config}) {
+    this.receivedAbi = receivedAbi;
+    this.receivedBlock = receivedBlock;
+    this.socketAddresses = socketAddresses;
+    if (
+      typeof socketAddress == "string" &&
+      !(socketAddresses && socketAddresses.length)
+    ) {
+      this.socketAddresses = [socketAddress];
+    }
+
+    this.config = config;
+    this.abi = null;
+    this.types = null;
+    this.tables = new Map();
+    this.blocksQueue = [];
+    this.inProcessBlocks = false;
+    this.socket_index = 0;
+    this.currentArgs = null;
+    this.connected = false;
+    this.connecting = false;
+    this.connectionRetries = 0;
+    this.maxConnectionRetries = 100;
+    this.logger = require("../connections/logger")(
+      "eosdac-statereceiver-logger",
+      this.config.logger
+    );
+
+    this.connect(this.socketAddresses[this.socket_index]);
+  }
+
+  connect(endpoint) {
+    if (!this.connected && !this.connecting) {
+      this.logger.info(`Websocket connecting to ${endpoint}`);
+
+      this.connecting = true;
+
+      this.ws = new WebSocket(endpoint, { perMessageDeflate: false });
+      this.ws.on("open", () => this.onConnect());
+      this.ws.on("message", (data) => this.onMessage(data));
+      // this.ws.on('error', () => this.onError());
+      this.ws.on("close", (e) => this.onClose(e));
+      this.ws.on("error", (e) => {
+        this.logger.error(`Websocket error`, e);
+      });
+      // this.ws.on('close', (e) => {this.logger.error(`Websocket close`, e)});
+    }
+  }
+
+  disconnect(force) {
+    if (force) {
+      this.logger.info(`Force closing connection`);
+      this.ws.removeAllListeners();
+      this.ws.terminate();
+    } else {
+      this.logger.info(`Closing connection`);
+      this.ws.close();
+    }
+  }
+
+  reconnect() {
+    if (this.connectionRetries > this.maxConnectionRetries) {
+      this.logger.error(
+        `Exceeded max reconnection attempts of ${this.maxConnectionRetries}`
+      );
+      return;
+    } else {
+      const endpoint = this.nextEndpoint();
+      this.logger.info(`Reconnecting to ${endpoint}...`);
+      const timeout = Math.pow(2, this.connectionRetries / 5) * 1000;
+      this.logger.info(`Retrying with delay of ${timeout / 1000}s`);
+      setTimeout(() => {
+        this.connect(endpoint);
+      }, timeout);
+      this.connectionRetries++;
+    }
+  }
+
+  nextEndpoint() {
+    let next_index = ++this.socket_index;
+
+    if (next_index >= this.socketAddresses.length) {
+      next_index = 0;
+    }
+    this.socket_index = next_index;
+
+    return this.socketAddresses[this.socket_index];
+  }
+
+  serialize(type, value) {
+    const buffer = new Serialize.SerialBuffer({
+      textEncoder: new TextEncoder(),
+      textDecoder: new TextDecoder(),
+    });
+    Serialize.getType(this.types, type).serialize(buffer, value);
+    return buffer.asUint8Array();
+  }
+
+  deserialize(type, array) {
+    const buffer = new Serialize.SerialBuffer({
+      textEncoder: new TextEncoder(),
+      textDecoder: new TextDecoder(),
+      array,
+    });
+    let result = Serialize.getType(this.types, type).deserialize(
+      buffer,
+      new Serialize.SerializerState({ bytesAsUint8Array: true })
+    );
+    if (buffer.readPos != array.length) throw new Error("oops: " + type); // todo: remove check
+    // {
+    //     this.logger.info(result.actions[0].authorization[0].actor);
+    //     //this.logger.info('oops: ' + type);
+    // }
+    return result;
+  }
+
+  toJsonUnpackTransaction(x) {
+    return JSON.stringify(
+      x,
+      (k, v) => {
+        if (k === "trx" && Array.isArray(v) && v[0] === "packed_transaction") {
+          const pt = v[1];
+          let packed_trx = pt.packed_trx;
+          this.logger.info(`Compression is ${pt.compression}`);
+          if (pt.compression === 0)
+            packed_trx = this.deserialize("transaction", packed_trx);
+          else if (pt.compression === 1)
+            packed_trx = this.deserialize(
+              "transaction",
+              zlib.unzipSync(packed_trx)
+            );
+          return { ...pt, packed_trx };
         }
+        if (k === "packed_trx" && v instanceof Uint8Array)
+          return this.deserialize("transaction", v);
+        if (v instanceof Uint8Array) return `(${v.length} bytes)`;
+        return v;
+      },
+      4
+    );
+  }
 
-        this.abi = null;
-        this.types = null;
-        this.tables = new Map;
-        this.blocksQueue = [];
-        this.inProcessBlocks = false;
-        this.socket_index = 0;
-        this.currentArgs = null;
-        this.connected = false;
-        this.connecting = false;
-        this.connectionRetries = 0;
-        this.maxConnectionRetries = 100;
+  send(request) {
+    this.ws.send(this.serialize("request", request));
+  }
 
-        this.connect(this.socketAddresses[this.socket_index]);
+  onConnect() {
+    this.connected = true;
+    this.connecting = false;
+    this.connectionRetries = 0;
+  }
+
+  onMessage(data) {
+    try {
+      if (!this.abi) {
+        this.logger.info("receiving abi");
+        this.rawabi = data;
+        this.abi = JSON.parse(data);
+        this.types = Serialize.getTypesFromAbi(
+          Serialize.createInitialTypes(),
+          this.abi
+        );
+        for (const table of this.abi.tables)
+          this.tables.set(table.name, table.type);
+        if (this.receivedAbi) this.receivedAbi();
+      } else {
+        const [type, response] = this.deserialize("result", data);
+        this[type](response);
+      }
+    } catch (e) {
+      this.logger.info(e);
+      process.exit(1);
     }
+  }
 
-    connect(endpoint){
-        if (!this.connected && !this.connecting){
-            console.log(`Websocket connecting to ${endpoint}`);
+  onClose(code) {
+    this.logger.error(
+      `Websocket disconnected from ${
+        this.socketAddresses[this.socket_index]
+      } with code ${code}`
+    );
+    // this.ws.terminate();
+    this.abi = null;
+    this.types = null;
+    this.tables = new Map();
+    this.blocksQueue = [];
+    this.inProcessBlocks = false;
+    this.connected = false;
+    this.connecting = false;
 
-            this.connecting = true;
-
-            this.ws = new WebSocket(endpoint, { perMessageDeflate: false });
-            this.ws.on('open', () => this.onConnect());
-            this.ws.on('message', data => this.onMessage(data));
-            // this.ws.on('error', () => this.onError());
-            this.ws.on('close', (e) => this.onClose(e));
-            this.ws.on('error', (e) => {console.error(`Websocket error`, e)});
-            // this.ws.on('close', (e) => {console.error(`Websocket close`, e)});
-        }
+    if (code !== 1000) {
+      // 1000 = closed by me normally
+      this.reconnect();
     }
+  }
 
-    disconnect(force) {
-        if (force) {
-            console.log(`Force closing connection`);
-            this.ws.removeAllListeners();
-            this.ws.terminate();
-        } else {
-            console.log(`Closing connection`);
-            this.ws.close();
-        }
+  onOpen() {
+    this.requestBlocks(this.currentArgs);
+  }
+
+  requestStatus() {
+    this.send(["get_status_request_v0", {}]);
+  }
+
+  requestBlocks(requestArgs) {
+    if (!this.currentArgs) {
+      this.currentArgs = {
+        start_block_num: 0,
+        end_block_num: 0xffffffff,
+        max_messages_in_flight: 5,
+        have_positions: [],
+        irreversible_only: false,
+        fetch_block: false,
+        fetch_traces: false,
+        fetch_deltas: false,
+        ...requestArgs,
+      };
     }
+    this.send(["get_blocks_request_v0", this.currentArgs]);
+  }
 
-    reconnect(){
-        if (this.connectionRetries > this.maxConnectionRetries){
-            console.error(`Exceeded max reconnection attempts of ${this.maxConnectionRetries}`);
-            return;
-        }
-        else {
-            const endpoint = this.nextEndpoint();
-            console.log(`Reconnecting to ${endpoint}...`);
-            const timeout = Math.pow(2, this.connectionRetries/5) * 1000;
-            console.log(`Retrying with delay of ${timeout / 1000}s`);
-            setTimeout(() => {
-                this.connect(endpoint);
-            }, timeout);
-            this.connectionRetries++;
-        }
+  get_status_result_v0(response) {
+    this.logger.info(response);
+  }
+
+  get_blocks_result_v0(response) {
+    this.blocksQueue.push(response);
+    this.processBlocks();
+  }
+
+  async processBlocks() {
+    if (this.inProcessBlocks) return;
+    this.inProcessBlocks = true;
+    while (this.blocksQueue.length) {
+      let response = this.blocksQueue.shift();
+      if (response.this_block) {
+        let block_num = response.this_block.block_num;
+        this.currentArgs.start_block_num = block_num - 50; // replay 25 seconds
+      }
+      this.send(["get_blocks_ack_request_v0", { num_messages: 1 }]);
+      let block,
+        traces = [],
+        deltas = [];
+      if (
+        this.currentArgs.fetch_block &&
+        response.block &&
+        response.block.length
+      )
+        block = this.deserialize("signed_block", response.block);
+      if (
+        this.currentArgs.fetch_traces &&
+        response.traces &&
+        response.traces.length
+      )
+        traces = this.deserialize("transaction_trace[]", response.traces);
+      if (
+        this.currentArgs.fetch_deltas &&
+        response.deltas &&
+        response.deltas.length
+      )
+        deltas = this.deserialize("table_delta[]", response.deltas);
+      await this.receivedBlock(response, block, traces, deltas);
     }
+    this.inProcessBlocks = false;
+  }
 
-    nextEndpoint(){
-        let next_index = ++this.socket_index;
-
-        if (next_index >= this.socketAddresses.length){
-            next_index = 0;
-        }
-        this.socket_index = next_index;
-
-        return this.socketAddresses[this.socket_index];
+  forEachRow(delta, f) {
+    const type = this.tables.get(delta.name);
+    for (let row of delta.rows) {
+      let data;
+      try {
+        data = this.deserialize(type, row.data);
+      } catch (e) {
+        this.logger.error(e);
+      }
+      if (data) f(row.present, data[1]);
     }
+  }
 
-    serialize(type, value) {
-        const buffer = new Serialize.SerialBuffer({ textEncoder: new TextEncoder, textDecoder: new TextDecoder });
-        Serialize.getType(this.types, type).serialize(buffer, value);
-        return buffer.asUint8Array();
-    }
-
-    deserialize(type, array) {
-        const buffer = new Serialize.SerialBuffer({ textEncoder: new TextEncoder, textDecoder: new TextDecoder, array });
-        let result = Serialize.getType(this.types, type).deserialize(buffer, new Serialize.SerializerState({ bytesAsUint8Array: true }));
-        if (buffer.readPos != array.length)
-            throw new Error('oops: ' + type); // todo: remove check
-        // {
-        //     console.log(result.actions[0].authorization[0].actor);
-        //     //console.log('oops: ' + type);
-        // }
-        return result;
-    }
-
-    toJsonUnpackTransaction(x) {
-        return JSON.stringify(x, (k, v) => {
-            if (k === 'trx' && Array.isArray(v) && v[0] === 'packed_transaction') {
-                const pt = v[1];
-                let packed_trx = pt.packed_trx;
-                console.log(`Compression is ${pt.compression}`);
-                if (pt.compression === 0)
-                    packed_trx = this.deserialize('transaction', packed_trx);
-                else if (pt.compression === 1)
-                    packed_trx = this.deserialize('transaction', zlib.unzipSync(packed_trx));
-                return { ...pt, packed_trx };
-            }
-            if (k === 'packed_trx' && v instanceof Uint8Array)
-                return this.deserialize('transaction', v);
-            if (v instanceof Uint8Array)
-                return `(${v.length} bytes)`;
-            return v;
-        }, 4)
-    }
-
-    send(request) {
-        this.ws.send(this.serialize('request', request));
-    }
-
-    onConnect(){
-        this.connected = true;
-        this.connecting = false;
-        this.connectionRetries = 0;
-    }
-
-    onMessage(data) {
-        try {
-            if (!this.abi) {
-                console.log('receiving abi')
-                this.rawabi = data;
-                this.abi = JSON.parse(data);
-                this.types = Serialize.getTypesFromAbi(Serialize.createInitialTypes(), this.abi);
-                for (const table of this.abi.tables)
-                    this.tables.set(table.name, table.type);
-                if (this.receivedAbi)
-                    this.receivedAbi();
-            } else {
-                const [type, response] = this.deserialize('result', data);
-                this[type](response);
-            }
-        } catch (e) {
-            console.log(e);
-            process.exit(1);
-        }
-    }
-
-    onClose(code) {
-        console.error(`Websocket disconnected from ${this.socketAddresses[this.socket_index]} with code ${code}`);
-        // this.ws.terminate();
-        this.abi = null;
-        this.types = null;
-        this.tables = new Map;
-        this.blocksQueue = [];
-        this.inProcessBlocks = false;
-        this.connected = false;
-        this.connecting = false;
-
-        if (code !== 1000){
-            // 1000 = closed by me normally
-            this.reconnect();
-        }
-
-    }
-
-    onOpen(){
-        this.requestBlocks(this.currentArgs)
-    }
-
-    requestStatus() {
-        this.send(['get_status_request_v0', {}]);
-    }
-
-    requestBlocks(requestArgs) {
-        if (!this.currentArgs){
-            this.currentArgs = {
-                start_block_num: 0,
-                end_block_num: 0xffffffff,
-                max_messages_in_flight: 5,
-                have_positions: [],
-                irreversible_only: false,
-                fetch_block: false,
-                fetch_traces: false,
-                fetch_deltas: false,
-                ...requestArgs
-            };
-        }
-        this.send(['get_blocks_request_v0', this.currentArgs]);
-    }
-
-    get_status_result_v0(response) {
-        console.log(response);
-    }
-
-    get_blocks_result_v0(response) {
-        this.blocksQueue.push(response);
-        this.processBlocks();
-    }
-
-    async processBlocks() {
-        if (this.inProcessBlocks)
-            return;
-        this.inProcessBlocks = true;
-        while (this.blocksQueue.length) {
-            let response = this.blocksQueue.shift();
-            if (response.this_block){
-                let block_num = response.this_block.block_num;
-                this.currentArgs.start_block_num = block_num - 50; // replay 25 seconds
-            }
-            this.send(['get_blocks_ack_request_v0', { num_messages: 1 }]);
-            let block, traces = [], deltas = [];
-            if (this.currentArgs.fetch_block && response.block && response.block.length)
-                block = this.deserialize('signed_block', response.block);
-            if (this.currentArgs.fetch_traces && response.traces && response.traces.length)
-                traces = this.deserialize('transaction_trace[]', response.traces);
-            if (this.currentArgs.fetch_deltas && response.deltas && response.deltas.length)
-                deltas = this.deserialize('table_delta[]', response.deltas);
-            await this.receivedBlock(response, block, traces, deltas);
-        }
-        this.inProcessBlocks = false;
-    }
-
-    forEachRow(delta, f) {
-        const type = this.tables.get(delta.name);
-        for (let row of delta.rows) {
-            let data;
-            try {
-                data = this.deserialize(type, row.data);
-            } catch (e) {
-                console.error(e);
-            }
-            if (data)
-                f(row.present, data[1]);
-        }
-    }
-
-    dumpDelta(delta, extra) {
-        this.forEachRow(delta, (present, data) => {
-            console.log(this.toJsonUnpackTransaction({ ...extra, present, data }));
-        });
-    }
+  dumpDelta(delta, extra) {
+    this.forEachRow(delta, (present, data) => {
+      this.logger.info(this.toJsonUnpackTransaction({ ...extra, present, data }));
+    });
+  }
 } // Connection
 
-
-module.exports = {Connection}
+module.exports = { Connection };

--- a/src/state-receiver/index.js
+++ b/src/state-receiver/index.js
@@ -1,247 +1,283 @@
-const { Connection } = require("./connection")
+const { Connection } = require("./connection");
 
+const SERIAL = 0;
+const PARALLEL = 1;
 
 class StateReceiver {
-    /* mode 0 = serial, 1 = parallel */
-    constructor({ startBlock = 0, endBlock = 0xffffffff, config, mode = 0, irreversibleOnly = false }){
-        this.trace_handlers = []
-        this.delta_handlers = []
-        this.done_handlers = []
-        this.progress_handlers = []
-        this.connected_handlers = []
-        this.block_handlers = []
-        this.fork_handlers = []
-        this.irreversible_only = irreversibleOnly
+  /* mode 0 = serial, 1 = parallel */
+  constructor({
+    startBlock = 0,
+    endBlock = 0xffffffff,
+    config,
+    mode = 0,
+    irreversibleOnly = false,
+  }) {
+    this.trace_handlers = [];
+    this.delta_handlers = [];
+    this.done_handlers = [];
+    this.progress_handlers = [];
+    this.connected_handlers = [];
+    this.block_handlers = [];
+    this.fork_handlers = [];
+    this.irreversible_only = irreversibleOnly;
+    this.start_time = 0;
 
-        // console.log(config)
+    this.config = config;
+    this.mode = mode;
 
-        this.config = config
-        this.mode = mode
+    this.start_block = startBlock;
+    this.end_block = endBlock;
+    this.current_block = -1;
+    this.complete = true;
 
-        this.start_block = startBlock
-        this.end_block = endBlock
-        this.current_block = -1
-        this.complete = true
+    this.logger = require("../connections/logger")(
+      "eosdac-statereceiver",
+      this.config.logger
+    );
+    this.logger.info(
+      `Created StateReceiver in ${this.getMode()} mode, Start : ${startBlock}, End : ${endBlock}`
+    );
+  }
 
-        const mode_str = (mode==0)?'serial':'parallel';
+  getMode() {
+    return this.mode == SERIAL ? "serial" : "parallel";
+  }
 
-        console.log(`Created StateReceiver, Start : ${startBlock}, End : ${endBlock}, Mode : ${mode_str}`);
+  parseDate(fullStr) {
+    const [fullDate] = fullStr.split(".");
+    const [dateStr, timeStr] = fullDate.split("T");
+    const [year, month, day] = dateStr.split("-");
+    const [hourStr, minuteStr, secondStr] = timeStr.split(":");
 
+    const dt = new Date();
+    dt.setUTCFullYear(year);
+    dt.setUTCMonth(month - 1);
+    dt.setUTCDate(day);
+    dt.setUTCHours(hourStr);
+    dt.setUTCMinutes(minuteStr);
+    dt.setUTCSeconds(secondStr);
+
+    return dt.getTime();
+  }
+
+  registerBlockHandler(h) {
+    this.block_handlers.push(h);
+  }
+
+  registerDoneHandler(h) {
+    this.done_handlers.push(h);
+  }
+
+  registerTraceHandler(h) {
+    this.trace_handlers.push(h);
+  }
+
+  registerDeltaHandler(h) {
+    this.delta_handlers.push(h);
+  }
+
+  registerProgressHandler(h) {
+    this.progress_handlers.push(h);
+  }
+
+  registerForkHandler(h) {
+    this.fork_handlers.push(h);
+  }
+
+  registerConnectedHandler(h) {
+    this.connected_handlers.push(h);
+  }
+
+  status() {
+    const start = this.start_block;
+    const end = this.end_block;
+    const current = this.current_block;
+
+    return { start, end, current };
+  }
+
+  async stop(force) {
+    this.logger.info(`Stopping StateReceiver`);
+    this.complete = false;
+    this.trace_handlers = [];
+    this.delta_handlers = [];
+    this.block_handlers = [];
+    this.connection.disconnect(force);
+  }
+
+  async start() {
+    this.logger.info(`Starting StateReceiver`);
+    this.complete = false;
+    this.start_time = performance.now();
+
+    this.connection = new Connection({
+      socketAddress: this.config.eos.wsEndpoint,
+      socketAddresses: this.config.eos.wsEndpoints,
+      receivedAbi: (() => {
+        this.requestBlocks();
+
+        this.connected_handlers.forEach(
+          ((handler) => {
+            handler(this.connection);
+          }).bind(this)
+        );
+      }).bind(this),
+      receivedBlock: this.receivedBlock.bind(this),
+    });
+  }
+
+  async restart(startBlock, endBlock) {
+    this.logger.info(`Restarting StateReceiver`);
+
+    this.complete = false;
+    this.start_time = performance.now();
+
+    this.start_block = startBlock;
+    this.end_block = endBlock;
+
+    this.connection = new Connection({
+      socketAddress: this.config.eos.wsEndpoint,
+      socketAddresses: this.config.eos.wsEndpoints,
+      receivedAbi: (() => {
+        this.requestBlocks();
+
+        this.connected_handlers.forEach(
+          ((handler) => {
+            handler(this.connection);
+          }).bind(this)
+        );
+      }).bind(this),
+      receivedBlock: this.receivedBlock.bind(this),
+    });
+    // await this.requestBlocks()
+  }
+
+  destroy() {
+    this.logger.info(`Destroying StateReceiver`);
+  }
+
+  async requestBlocks() {
+    try {
+      this.current_block = 0;
+
+      await this.connection.requestBlocks({
+        irreversible_only: this.irreversible_only,
+        start_block_num: parseInt(this.start_block),
+        end_block_num: parseInt(this.end_block),
+        have_positions: [],
+        fetch_block: true,
+        fetch_traces: this.trace_handlers.length > 0,
+        fetch_deltas: this.delta_handlers.length > 0,
+      });
+    } catch (e) {
+      this.logger.error(e);
+      process.exit(1);
+    }
+  }
+
+  async handleFork(block_num) {
+    this.logger.info("FORK HANDLERS", this.fork_handlers.length);
+    this.fork_handlers.forEach((h) => {
+      h(block_num);
+    });
+  }
+
+  async receivedBlock(response, block, traces, deltas) {
+    if (!response.this_block) return;
+    let block_num = response.this_block.block_num;
+    //this.logger.info(response.this_block)
+    // this.logger.info(`Received block ${block_num}`)
+
+    if (this.mode === 0 && block_num <= this.current_block) {
+      this.logger.info(
+        `Detected fork in serial mode: current:${block_num} <= head:${this.current_block}`
+      );
+      await this.handleFork(block_num);
     }
 
-    parseDate (fullStr) {
-        const [fullDate] = fullStr.split('.')
-        const [dateStr, timeStr] = fullDate.split('T')
-        const [year, month, day] = dateStr.split('-')
-        const [hourStr, minuteStr, secondStr] = timeStr.split(':')
+    this.complete = false;
 
-        const dt = new Date()
-        dt.setUTCFullYear(year)
-        dt.setUTCMonth(month - 1)
-        dt.setUTCDate(day)
-        dt.setUTCHours(hourStr)
-        dt.setUTCMinutes(minuteStr)
-        dt.setUTCSeconds(secondStr)
+    this.current_block = block_num;
 
-        return dt.getTime()
+    if (!(block_num % 1000)) {
+      let { start, end, current } = this.status();
+      //this.logger.info(`Start: ${start}, End: ${end}, Current: ${current}`);
+
+      // this.connection.requestStatus()
+      // this.queue.inactiveCount((err, total) => {
+      //     this.logger.info("redis queue length " + total)
+      // })
     }
 
-    registerBlockHandler(h){
-        this.block_handlers.push(h)
+    let block_timestamp = null;
+    if (block) {
+      block_timestamp = new Date(
+        this.parseDate(block.timestamp.replace([".000", ".500"], "Z"))
+      );
+    } else {
+      block_timestamp = new Date();
     }
 
-    registerDoneHandler(h){
-        this.done_handlers.push(h)
+    if (deltas && deltas.length) {
+      this.delta_handlers.forEach(
+        ((handler) => {
+          if (this.mode === 0) {
+            handler.processDelta(
+              block_num,
+              deltas,
+              this.connection.types,
+              block_timestamp
+            );
+          } else {
+            handler.queueDelta(
+              block_num,
+              deltas,
+              this.connection.types,
+              block_timestamp
+            );
+          }
+        }).bind(this)
+      );
     }
 
-    registerTraceHandler(h){
-        this.trace_handlers.push(h)
-    }
-
-    registerDeltaHandler(h){
-        this.delta_handlers.push(h)
-    }
-
-    registerProgressHandler(h){
-        this.progress_handlers.push(h)
-    }
-
-    registerForkHandler(h){
-        this.fork_handlers.push(h)
-    }
-
-    registerConnectedHandler(h){
-        this.connected_handlers.push(h)
-    }
-
-    status(){
-        const start = this.start_block
-        const end = this.end_block
-        const current = this.current_block
-
-        return {start, end, current}
-    }
-
-    async stop(force) {
-        this.complete = false;
-        this.trace_handlers = [];
-        this.delta_handlers = [];
-        this.block_handlers = [];
-        this.connection.disconnect(force);
-        
-    }
-
-    async start(){
-        this.complete = false
-
-        this.connection = new Connection({
-            socketAddress: this.config.eos.wsEndpoint,
-            socketAddresses: this.config.eos.wsEndpoints,
-            receivedAbi: (() => {
-                this.requestBlocks()
-
-                this.connected_handlers.forEach(((handler) => {
-                    handler(this.connection)
-                }).bind(this))
-            }).bind(this),
-            receivedBlock: this.receivedBlock.bind(this)
-        });
-    }
-
-    async restart(startBlock, endBlock){
-        this.complete = false
-
-        this.start_block = startBlock
-        this.end_block = endBlock
-
-        this.connection = new Connection({
-            socketAddress: this.config.eos.wsEndpoint,
-            socketAddresses: this.config.eos.wsEndpoints,
-            receivedAbi: (() => {
-                this.requestBlocks()
-
-                this.connected_handlers.forEach(((handler) => {
-                    handler(this.connection)
-                }).bind(this))
-            }).bind(this),
-            receivedBlock: this.receivedBlock.bind(this)
-        });
-        // await this.requestBlocks()
-    }
-
-    destroy(){
-        console.log(`Destroying (TODO)`)
-    }
-
-    async requestBlocks(){
-        try {
-            this.current_block = 0;
-
-            await this.connection.requestBlocks({
-                irreversible_only: this.irreversible_only,
-                start_block_num: parseInt(this.start_block),
-                end_block_num: parseInt(this.end_block),
-                have_positions:[],
-                fetch_block: true,
-                fetch_traces: (this.trace_handlers.length > 0),
-                fetch_deltas: (this.delta_handlers.length > 0),
-            });
-        } catch (e) {
-            console.error(e);
-            process.exit(1);
+    if (traces) {
+      this.trace_handlers.forEach((handler) => {
+        if (this.mode === 0) {
+          handler.processTrace(block_num, traces, block_timestamp);
+        } else {
+          handler.queueTrace(block_num, traces, block_timestamp);
         }
+      });
+    }
+    if (block) {
+      this.block_handlers.forEach((handler) => {
+        if (this.mode === 0) {
+          handler.processBlock(block_num, block);
+        } else {
+          handler.queueBlock(block_num, block);
+        }
+      });
     }
 
-    async handleFork(block_num){
-        console.log('FORK HANDLERS', this.fork_handlers.length)
-        this.fork_handlers.forEach((h) => {
-            h(block_num)
-        })
+    if (this.current_block === this.end_block - 1) {
+      this.complete = true;
+      const duration = performance.now() - this.start_time;
+      this.logger.info(
+        `Done > ${Math.round(duration / 1000)} seconds to complete: ${
+          this.start_block
+        }, End: ${this.end_block}`
+      );
+
+      this.done_handlers.forEach((handler) => {
+        handler();
+      });
+      this.connection.disconnect();
     }
 
-    async receivedBlock(response, block, traces, deltas) {
-        if (!response.this_block)
-            return;
-        let block_num = response.this_block.block_num;
-        //console.log(response.this_block)
-        // console.log(`Received block ${block_num}`)
-
-        if ( this.mode === 0 && block_num <= this.current_block ){
-            console.log(`Detected fork in serial mode: current:${block_num} <= head:${this.current_block}`)
-            await this.handleFork(block_num)
-        }
-
-        this.complete = false
-
-        this.current_block = block_num
-
-        if (!(block_num % 1000)){
-            console.info(`StateReceiver : received block ${block_num}`);
-            let {start, end, current} = this.status()
-            console.info(`Start: ${start}, End: ${end}, Current: ${current}`)
-
-            // this.connection.requestStatus()
-            // this.queue.inactiveCount((err, total) => {
-            //     console.info("redis queue length " + total)
-            // })
-        }
-
-        let block_timestamp = null;
-        if (block){
-            block_timestamp = new Date(this.parseDate(block.timestamp.replace(['.000', '.500'], 'Z')));
-        }
-        else {
-            block_timestamp = new Date();
-        }
-
-        if (deltas && deltas.length){
-            this.delta_handlers.forEach(((handler) => {
-                if (this.mode === 0){
-                    handler.processDelta(block_num, deltas, this.connection.types, block_timestamp)
-                }
-                else {
-                    handler.queueDelta(block_num, deltas, this.connection.types, block_timestamp)
-                }
-            }).bind(this))
-        }
-
-        if (traces){
-            this.trace_handlers.forEach((handler) => {
-                if (this.mode === 0){
-                    handler.processTrace(block_num, traces, block_timestamp)
-                }
-                else {
-                    handler.queueTrace(block_num, traces, block_timestamp)
-                }
-            })
-        }
-        if (block){
-            this.block_handlers.forEach((handler) => {
-                if (this.mode === 0){
-                    handler.processBlock(block_num, block)
-                }
-                else {
-                    handler.queueBlock(block_num, block)
-                }
-            })
-        }
-
-        if (this.current_block === this.end_block -1){
-            console.log(`State Handler complete!`)
-            this.complete = true
-            this.done_handlers.forEach((handler) => {
-                handler()
-            })
-            this.connection.disconnect()
-        }
-
-        this.progress_handlers.forEach((handler) => {
-            handler(100 * ((block_num - this.start_block) / this.end_block))
-        })
-
-
-    } // receivedBlock
+    this.progress_handlers.forEach((handler) => {
+      handler(100 * ((block_num - this.start_block) / this.end_block));
+    });
+  } // receivedBlock
 }
 
-
-module.exports = StateReceiver
+module.exports = StateReceiver;


### PR DESCRIPTION
This commit has a primary fix and secondary changes.

1. When the StateReceiver's Connection is closed, the while loop in processBlocks is still running, and has been trying to make additional ack websocket calls after connection is gone. This fix checks for a null response_block, which occurs only after the entire range has been processed, and when found breaks out of the while loop.

2. To test a small range, and to respect filler's argument --end-block, some minor changes to filler so that end of range can be specified when running in default mode.

3. The loggers were updated to segment the writing of warning, info and error logs. This is useful for troubleshooting, but might not be needed in a production environment. Let me know if you'd like a commit with only steps 1 and 2.

Note StateReceiver and connection diffs appear much bigger than they seem to be, due to reformatting of the source. Sorry about that; I realize it makes it harder to find the actual diffs.