### PR TITLE
make queues durable

### DIFF
--- a/src/connections/amq.js
+++ b/src/connections/amq.js
@@ -97,7 +97,8 @@ class Amq {
                 msg = Buffer.from(msg)
             }
             this.logger.info(`Message sent to queue ${queue_name}`);
-            return this.channel.sendToQueue(queue_name, msg)
+            return this.channel.sendToQueue(queue_name, msg, {deliveryMode: true})
+)
         } else {
             this.logger.error('Cannot perform operation "send", AMQ is not connected!');
         }

--- a/src/rabbitsender.js
+++ b/src/rabbitsender.js
@@ -45,7 +45,8 @@ class RabbitSender {
             msg = Buffer.from(msg)
         }
 
-        return this.channel.sendToQueue(queue_name, msg)
+        return this.channel.sendToQueue(queue_name, msg, {deliveryMode: true})
+)
     }
 
     async listen(queue_name, cb) {


### PR DESCRIPTION
I found what was missing to make the rabbitmq's actually durable. For AMQP <= 0.9.1, we needed another argument when calling sendToQueue.

"Queues can be durable or transient. Metadata of a durable queue is stored on disk, while metadata of a transient queue is stored in memory when possible. The same distinction is made for [messages at publishing time](https://www.rabbitmq.com/publishers.html#message-properties) in some protocols, e.g. AMQP 0-9-1 and MQTT."

See supporting docs:

https://www.rabbitmq.com/queues.html#durability
https://www.rabbitmq.com/publishers.html#message-properties