### PR TITLE
Range scan nodes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM node:17-alpine3.12
 
 ARG CONFIG
 ENV CONFIG=$CONFIG
-
 RUN apk add curl
 
 RUN mkdir -p /var/www/api
@@ -12,8 +11,9 @@ ADD scripts /var/www/api/scripts
 ADD src /var/www/api/src
 
 COPY package.json tokens.json /var/www/api/
-COPY example.config.js /var/www/api/${CONFIG}.config.js
+COPY ${CONFIG}.config.js /var/www/api/${CONFIG}.config.js
 
 WORKDIR /var/www/api
+ENV NODE_PATH node_modules
 
 RUN yarn

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -45,15 +45,22 @@ services:
 
   queue: # login guest:guest
     image: rabbitmq:management
+    container_name: queue_mainnet
     restart: always
+    ulimits:
+      nofile:
+        soft: 128000
+        hard: 128000
     ports:
-      - '5672:5672'
-      - '15672:15672'
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:15672']
-      interval: 30s
-      timeout: 10s
-      retries: 5
+    #  - '5672:5672'
+      - '43235:15672'
+    environment:
+      RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: '-rabbit consumer_timeout 5400000'
+    #healthcheck:
+    #  test: ['CMD', 'curl', '-f', 'http://queue:15672']
+    #  interval: 30s
+    #  timeout: 10s
+    #  retries: 5
 
 volumes:
   database:

--- a/mainnet.config.js
+++ b/mainnet.config.js
@@ -1,23 +1,23 @@
 module.exports = {
     // redisPrefix: 'q',
-    fillClusterSize: 10,
-    clusterSize: 6,
+    fillClusterSize: 14,
+    clusterSize: 8,
     // redis: {
     //     port: 6379,
     //     host: '169.56.83.184',
     //     auth: ''
     // },
     mongo: {
-        url: 'mongodb://eosdac-api-db-1:27017',
+        url: 'mongodb://db_mainnet:27017',
         dbName: 'alienworlds_dao_mainnet',
         traceCollection: 'traces',
         stateCollection: 'states'
     },
     amq: {
-        connectionString: 'amqp://guest:guest@eosdac-api-queue-1/'
+	    connectionString: 'amqp://guest:guest@queue_mainnet/'
     },
     ws: {
-        host: 'eosdac-api-ws-1',
+        host: 'ws',
         port: '3031'
     },
     ipc: {
@@ -30,8 +30,8 @@ module.exports = {
         //        endpoint: 'http://127.0.0.1:38888',
         //        wsEndpoint: 'ws://127.0.0.1:38080',
         //        wsEndpoints: ['ws://127.0.0.1:38080'],
-        endpoint: 'https://wax.eosdac.io',
-        wsEndpoint: 'ws://157.90.129.75:28080',
+        endpoint: 'https://waxnode.alienworlds.io',
+        wsEndpoint: 'ws://ship.alienworlds.io:28080',
         wsEndpoints: ['ws://ship.alienworlds.io:28080'],
         msigContract: 'msig.worlds',
         custodianContract: 'dao.worlds',
@@ -40,7 +40,8 @@ module.exports = {
         // the first block that includes any dac contract actions including the initial setcode
         // dao.worlds contract was first set 105376981 
         // 105578904 - first stprofile block
-        dacGenesisBlock: 105376981,
+        // dacGenesisBlock: 123428449,
+        dacGenesisBlock: 173000000,
     },
     "logger": {
         "level": "info",

--- a/src/block-scan-node.js
+++ b/src/block-scan-node.js
@@ -1,0 +1,176 @@
+
+const { MongoClient } = require('mongodb');
+const uri = "mongodb://localhost:27017/blockranges";
+const mongo_client = new MongoClient(uri, { useNewUrlParser: true, useUnifiedTopology: true });
+
+
+function BlockRangeNode(data, db_collection) {
+    let _data = data
+
+    var db_collection = db_collection
+
+    return {
+        data: () => _data,
+        async _find_completed_parent_node() {
+            if (!_data.parent_id) { return result }
+            await db_collection.deleteOne({ _id: _data._id })
+
+            // fetch all child nodes with parent id that matches this parent_id
+            const matching_parent_result = await db_collection.find({ parent_id: _data.parent_id })
+            if (await matching_parent_result.count() == 0) {
+                const parentRaw = await db_collection.findOne({ _id: _data.parent_id })
+                const parent = BlockRangeNode(parentRaw, db_collection)
+                if (parent) {
+                    return await parent._find_completed_parent_node()
+                }
+            }
+            return this
+        },
+
+        subdivide(numberOfChildren, maxChunkSize) {
+            var nodes_to_persist = []
+            const chunkSize = Math.ceil((_data._id.end - _data._id.start) / numberOfChildren)
+            var start = _data._id.start
+            while (start < _data._id.end) {
+                const child_end = Math.min(start + chunkSize, _data._id.end)
+                var node = BlockRangeNode(
+                    {
+                        _id: {
+                            start: start,
+                            end: child_end,
+                            scan_key: _data._id.scan_key
+                        },
+                        tree_depth: _data.tree_depth + 1,
+                        parent_id: _data._id
+                    })
+                if (child_end - start > maxChunkSize) {
+                    nodes_to_persist.push(...node.subdivide(numberOfChildren, maxChunkSize))
+                } else {
+                    node.set_is_leaf_node()
+                }
+                nodes_to_persist.push(node)
+                start += chunkSize
+            }
+
+            return nodes_to_persist
+        },
+
+        set_is_leaf_node() {
+            _data.is_leaf_node = true
+        },
+
+        async set_current_block_progress(new_value) {
+            if (!_data.is_leaf_node) {
+                throw new Error("This range has already completed scanning the blockchain.")
+            }
+            _data.current_block_progress = new_value
+
+            if (_data.current_block_progress == _data._id.end - 1) {
+                await this._find_completed_parent_node()
+                // log("completed_parent: ", JSON.stringify(completed_parent, null, 2))
+
+            } else {
+                await db_collection.updateOne(
+                    { _id: _data._id },
+                    {
+                        $set: {
+                            current_block_progress: _data.current_block_progress,
+                            time_stamp: new Date()
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+async function ScanCoordinator() {
+    var db_collection
+
+    await connectDb()
+
+    return {
+        async init_scan(start, end, scan_key, number_of_children, min_chunk_size) {
+            var nodes_to_persist = []
+            const root_node = BlockRangeNode({ _id: { start, end, scan_key }, tree_depth: 0 }, db_collection)
+            nodes_to_persist.push(root_node)
+
+            nodes_to_persist.push(...root_node.subdivide(number_of_children, min_chunk_size))
+            nodes_to_persist = nodes_to_persist.map(n => n.data())
+            await db_collection.insertMany(nodes_to_persist)
+        },
+
+        async get_number_leaf_nodes(scan_key) {
+            const result = await db_collection.countDocuments(
+                {
+                    "_id.scan_key": scan_key,
+                    "is_leaf_node": true,
+                })
+
+            return result
+        },
+
+        async deleteAll(scan_key) {
+            await db_collection.deleteMany({ "_id.scan_key": scan_key })
+        },
+
+        async find_range_for_block_num(block_num, scan_key) {
+            const result = await db_collection.find(
+                {
+                    "_id.start": { $lt: block_num }, "_id.end": { $gt: block_num }, "_id.scan_key": scan_key
+                }, { sort: { tree_depth: -1 } })
+            const raw = await result.next()
+            if (!raw) {
+                throw new Error(`No pending blockrange to scan for this blocknum: ${block_num}, scan_key: ${scan_key}`)
+            }
+            return BlockRangeNode(raw, db_collection)
+        },
+
+        async start_next_range(scan_key) {
+            const result = await db_collection.findOneAndUpdate(
+                {
+                    is_leaf_node: true
+                },
+                { $set: { time_stamp: new Date() } },
+                {
+                    sort: { time_stamp: 1 },
+                    returnDocument: "after"
+                }
+            )
+
+            const raw = await result.value
+            if (!raw) {
+                throw new Error(`No pending blockrange to scan forscan_key: ${scan_key}`)
+            }
+            return BlockRangeNode(raw, db_collection)
+        },
+
+        async update_current_block_progress(block_num, scan_key) {
+            let range = await this.find_range_for_block_num(block_num, scan_key)
+            await range.set_current_block_progress(block_num)
+        }
+    }
+
+    async function connectDb() {
+        db_collection = await _connectDb();
+        //     this.db_collection.createIndex({
+        //         "name": 1
+        //     }, { unique: true, background: true });
+
+    }
+
+    async function _connectDb() {
+        return new Promise((resolve, reject) => {
+            mongo_client.connect(err => {
+                const collection = mongo_client.db("eosdacapi").collection("blockranges");
+                if (err) {
+                    reject(err)
+                } else {
+                    resolve(collection)
+                }
+            });
+        })
+    }
+}
+
+module.exports = { ScanCoordinator };

--- a/src/blockscan.test.js
+++ b/src/blockscan.test.js
@@ -1,0 +1,64 @@
+
+const { ScanCoordinator } = require("./block-scan-node")
+
+const tester = async () => {
+    const coordinator = await ScanCoordinator()
+
+    const scan_key = "mykey"
+
+    await coordinator.deleteAll(scan_key)
+    console.log("deleted all")
+
+
+    // Creates a new scan tree from block 1 up to 730 with a unique key of "scan_key" to support different scan events. \
+    // The tree will subdivided recursively with 4 children in each branch until there is a max of 32 blocks in each leaf node.
+    await coordinator.init_scan(1, 730, scan_key, 4, 32)
+
+    const leafCount = await coordinator.get_number_leaf_nodes(scan_key)
+    console.log("count", leafCount)
+
+    // Should delete 1st range parent
+    await coordinator.update_current_block_progress(12, scan_key)
+    await coordinator.update_current_block_progress(24, scan_key)
+    await coordinator.update_current_block_progress(36, scan_key)
+    await coordinator.update_current_block_progress(46, scan_key)
+
+    // Should delete 2nd range parent
+    await coordinator.update_current_block_progress(58, scan_key)
+    await coordinator.update_current_block_progress(70, scan_key)
+    await coordinator.update_current_block_progress(82, scan_key)
+    await coordinator.update_current_block_progress(92, scan_key)
+
+    //should delete 3rd range parent
+    await coordinator.update_current_block_progress(102, scan_key) // should update but not delete anything
+    await coordinator.update_current_block_progress(104, scan_key)
+    // await coordinator.update_current_block_progress(104, scan_key) // should fail
+
+    await coordinator.update_current_block_progress(116, scan_key)
+    await coordinator.update_current_block_progress(128, scan_key)
+    await coordinator.update_current_block_progress(138, scan_key)
+
+    // should delete 4th range parent and the parent above
+    await coordinator.update_current_block_progress(150, scan_key)
+    await coordinator.update_current_block_progress(162, scan_key)
+    await coordinator.update_current_block_progress(174, scan_key)
+    await coordinator.update_current_block_progress(183, scan_key)
+
+    console.log("done updating and deleting first branch")
+
+    var nextRange = await coordinator.start_next_range(scan_key)
+    console.log("next:", JSON.stringify(nextRange.data(), null, 2))
+
+    nextRange = await coordinator.start_next_range(scan_key)
+    console.log("next:", JSON.stringify(nextRange.data(), null, 2))
+
+    nextRange = await coordinator.start_next_range(scan_key)
+    console.log("next:", JSON.stringify(nextRange.data(), null, 2))
+
+    await nextRange.set_current_block_progress(45)
+    console.log("next:", JSON.stringify(nextRange.data(), null, 2))
+
+    process.exit(0)
+}
+
+tester()

--- a/src/eosdac-blockrange.js
+++ b/src/eosdac-blockrange.js
@@ -51,15 +51,15 @@ class BlockRangeManager {
     workerExit(worker, code, signal) {
         this.logger.info(`Process exit`);
         if (signal) {
-            this.logger.warn(`FillManager : worker was killed by signal: ${signal}`);
+            this.logger.warn(`BlockRangeManager : worker was killed by signal: ${signal}`);
         } else if (code !== 0) {
-            this.logger.warn(`FillManager : worker exited with error code: ${code}`);
+            this.logger.warn(`BlockRangeManager : worker exited with error code: ${code}`);
         } else {
             if (this.job) {
                 // Job success
                 this.amq.ack(this.job);
             }
-            this.logger.info('FillManager : worker success!');
+            this.logger.info('BlockRangeManager : worker success!');
         }
 
         if (worker.isDead()) {
@@ -67,17 +67,18 @@ class BlockRangeManager {
                 this.amq.reject(this.job);
             }
 
-            this.logger.warn(`FillManager : Worker is dead, starting a new one`);
+            this.logger.warn(`BlockRangeManager : Worker is dead, starting a new one`);
             cluster.fork();
 
             if (worker.isMaster) {
-                this.logger.error('FillManager : Main thread died :(')
+                this.logger.error('BlockRangeManager : Main thread died :(')
             }
         }
 
     }
 
     async processBlockRange(job) {
+        console.log('BlockRange: Call processBlockRange!');
         this.job = job;
         //await this.amq.ack(job)
 

--- a/src/eosdac-filler.js
+++ b/src/eosdac-filler.js
@@ -164,6 +164,17 @@ class FillManager {
                 this.logger.info('Test complete')
                 // process.exit(0)
             });
+
+            this.amq.onDisconnected(() => {
+                this.br.stop(true);
+            });
+    
+            this.amq.onReconnected(() => {
+                this.br.registerTraceHandler(trace_handler);
+                this.br.registerDeltaHandler(delta_handler);
+                this.br.start();
+            });
+
             this.br.start()
         } else if (this.process_only) {
             if (cluster.isMaster) {
@@ -266,6 +277,16 @@ class FillManager {
             // this.logger.info(`StateReceiver completed`, job)
             this.amq.ack(job);
             this.logger.info(`Finished job ${start_block}-${end_block}`);
+        });
+
+        this.amq.onDisconnected(() => {
+            this.br.stop(true);
+        });
+
+        this.amq.onReconnected(() => {
+            this.br.registerDeltaHandler(delta_handler);
+            this.br.registerTraceHandler(block_handler);
+            this.br.start();
         });
 
         this.logger.info('StateReceiver created');

--- a/src/handlers/action-handler.js
+++ b/src/handlers/action-handler.js
@@ -107,6 +107,7 @@ class ActionHandler {
             sb_action.pushBytes(action.act.data);
 
             if (this.amq) {
+                try {
                 // this.logger.info(`Queueing action for ${action.act.account}::${action.act.name}`);
                 const block_buffer = new Int64(block_num).toBuffer();
                 const timestamp_buffer = this.int32ToBuffer(block_timestamp.getTime() / 1000);
@@ -116,6 +117,10 @@ class ActionHandler {
                 const action_buffer = Buffer.from(sb_action.array);
                 // this.logger.info(`Publishing action`)
                 this.amq.send('action', Buffer.concat([block_buffer, timestamp_buffer, trx_id_buffer, recv_buffer, global_buffer, action_buffer]))
+                } catch (error) {
+                    this.logger.info(`Error Queue Action ${action.act.account}:${action.act.name}`);
+                    console.error(error);
+                }
             } else {
                 console.error(`No queue when processing action for ${action.act.account}::${action.act.name} in ${trx_id}`, {action});
             }

--- a/src/state-receiver/connection.js
+++ b/src/state-receiver/connection.js
@@ -121,7 +121,13 @@ class Connection {
     }
 
     send(request) {
-        this.ws.send(this.serialize('request', request));
+        try {
+            this.ws.send(this.serialize('request', request));
+        } catch (error) {
+            console.log('An exception was caught while sending! connection process:', process.pid);
+            console.log('request', request);
+            console.log(error);
+        }
     }
 
     onConnect(){

--- a/src/state-receiver/index.js
+++ b/src/state-receiver/index.js
@@ -153,7 +153,6 @@ class StateReceiver {
     }
 
     async handleFork(block_num){
-        console.log('FORK HANDLERS', this.fork_handlers.length)
         this.fork_handlers.forEach((h) => {
             h(block_num)
         })
@@ -232,7 +231,7 @@ class StateReceiver {
             this.done_handlers.forEach((handler) => {
                 handler()
             })
-            this.connection.disconnect()
+            this.connection.disconnect(true);
         }
 
         this.progress_handlers.forEach((handler) => {


### PR DESCRIPTION
Demo Code to track ranges being scanned in mongo in a tree structure which can periodically be fetched from mongo and gradually deleted as sub trees are completed.

* `Scancoordinator`:
  * manages the connection to mongo
  * inits scan and subdivides a big range into a tree of child ranges that can be completed in parallel in small tasks.
  * Progress of each range can be tracked with the `current_block_progress` And when each reaches the end of the range the node gets removed from the tree and the tree parents get cleaned up.
  * a time_stamp tracks when a `BlockRangeNode` is picked up so multiple instances of `ScanCoordinator` will not pick up the same range across different machines.
  * A `scan_key` value allows multiple scan queues to be run with different ranges with a unique identifier. This would be for differentiating the scanning of history for different action listeners in the future.
* `BlockRangeNode` - A simple structure that is a node in the tree structure. contains:
  * a unique `_id` holds the { start, end, scan_key} values for each range
  * a reference to it's parent unless it's the root node.
  * a timestamp for when it was picked up for processing through the scan coordinator
  * a boolean marker to indicate if it's a leaf node to help with query filtering.