### PR TITLE
add dac_name query param

### DIFF
--- a/src/api-handlers/getProfile.js
+++ b/src/api-handlers/getProfile.js
@@ -5,21 +5,21 @@ const { loadConfig, loadDacConfig } = require('../functions');
 
 async function getProfile(fastify, request) {
     const config = loadConfig();
-    const { account, dac_name } = request.query;
-    const dacName = dac_name || config.eos.legacyDacs[0];
+    const { account, dac_id } = request.query;
+    const dacId = dac_id || config.eos.legacyDacs[0];
     const accounts = account.split(',');
-    const dacConfig = await loadDacConfig(fastify, dacName);
+    const dacConfig = await loadDacConfig(fastify, dacId);
 
     const db = fastify.mongo.db;
     const token_contract = dacConfig.symbol.contract;
 
     let legacy = false;
-    if (fastify.config.eos.legacyDacs && fastify.config.eos.legacyDacs.includes(dacName)){
-        fastify.log.info(`Got legacy dac ${dacName}`, {dacName});
+    if (fastify.config.eos.legacyDacs && fastify.config.eos.legacyDacs.includes(dacId)){
+        fastify.log.info(`Got legacy dac ${dacId}`, {dacName: dacId});
         legacy = true;
     }
 
-    const result = getProfiles(db, dacConfig, dacName, accounts, legacy);
+    const result = getProfiles(db, dacConfig, dacId, accounts, legacy);
 
 
     return result

--- a/src/connections/amq.js
+++ b/src/connections/amq.js
@@ -98,7 +98,6 @@ class Amq {
             }
             this.logger.info(`Message sent to queue ${queue_name}`);
             return this.channel.sendToQueue(queue_name, msg, {deliveryMode: true})
-)
         } else {
             this.logger.error('Cannot perform operation "send", AMQ is not connected!');
         }

--- a/src/functions.js
+++ b/src/functions.js
@@ -42,9 +42,9 @@ async function getRestartBlock() {
     return block
 }
 
-const loadDacConfig = async (fastify, dac_name) => {
+const loadDacConfig = async (fastify, dacId) => {
     const global_config = loadConfig();
-    const dac_config_cache = fastify.dac_cache_get(dac_name);
+    const dac_config_cache = fastify.dac_cache_get(dacId);
     if (dac_config_cache){
         fastify.log.info(`Returning cached dac info`);
         return dac_config_cache;
@@ -54,13 +54,13 @@ const loadDacConfig = async (fastify, dac_name) => {
             code: global_config.eos.dacDirectoryContract,
             scope: global_config.eos.dacDirectoryContract,
             table: 'dacs',
-            lower_bound: dac_name,
-            upper_bound: dac_name
+            lower_bound: dacId,
+            upper_bound: dacId
         });
 
         if (res.rows.length){
             const row = res.rows[0];
-            if (row.dac_id === dac_name){
+            if (row.dac_id === dacId){
                 const account_map = new Map();
                 row.accounts.forEach((acnt) => {
                     account_map.set(acnt.key, acnt.value);
@@ -72,13 +72,13 @@ const loadDacConfig = async (fastify, dac_name) => {
                     ref_map.set(ref.key, ref.value);
                 });
                 row.refs = ref_map;
-                fastify.dac_name_cache.set(dac_name, row);
+                fastify.dac_name_cache.set(dacId, row);
 
                 return row;
             }
         }
 
-        fastify.log.warn(`Could not find dac with ID ${dac_name}`);
+        fastify.log.warn(`Could not find dac with ID ${dacId}`);
         return null;
     }
 }

--- a/src/functions.js
+++ b/src/functions.js
@@ -42,5 +42,46 @@ async function getRestartBlock() {
     return block
 }
 
+const loadDacConfig = async (fastify, dac_name) => {
+    const global_config = loadConfig();
+    const dac_config_cache = fastify.dac_cache_get(dac_name);
+    if (dac_config_cache){
+        fastify.log.info(`Returning cached dac info`);
+        return dac_config_cache;
+    }
+    else {
+        const res = await fastify.eos.rpc.get_table_rows({
+            code: global_config.eos.dacDirectoryContract,
+            scope: global_config.eos.dacDirectoryContract,
+            table: 'dacs',
+            lower_bound: dac_name,
+            upper_bound: dac_name
+        });
 
-module.exports = {loadConfig, getRestartBlock};
+        if (res.rows.length){
+            const row = res.rows[0];
+            if (row.dac_id === dac_name){
+                const account_map = new Map();
+                row.accounts.forEach((acnt) => {
+                    account_map.set(acnt.key, acnt.value);
+                });
+                row.accounts = account_map;
+
+                const ref_map = new Map();
+                row.refs.forEach((ref) => {
+                    ref_map.set(ref.key, ref.value);
+                });
+                row.refs = ref_map;
+                fastify.dac_name_cache.set(dac_name, row);
+
+                return row;
+            }
+        }
+
+        fastify.log.warn(`Could not find dac with ID ${dac_name}`);
+        return null;
+    }
+}
+
+
+module.exports = {loadConfig, getRestartBlock, loadDacConfig};

--- a/src/profile-helper.js
+++ b/src/profile-helper.js
@@ -22,14 +22,14 @@ async function getMemberType(account, dacName, db){
     return member_type;
 }
 
-async function getProfiles(db, dac_config, dacName, accounts, legacy = false) {
+async function getProfiles(db, dac_config, dacId, accounts, legacy = false) {
     const collection = db.collection('actions');
     const cust_contract = dac_config.accounts.get(2);
 
-    const query = {"action.account": cust_contract, "action.name": "stprofile", "action.data.dac_id":dacName, "action.data.cand": {$in: accounts}};
+    const query = {"action.account": cust_contract, "action.name": "stprofile", "action.data.dac_id":dacId, "action.data.cand": {$in: accounts}};
 
     if (legacy){
-        query['action.data.dac_id'] = {$in: [dacName, null]};
+        query['action.data.dac_id'] = {$in: [dacId, null]};
         query['action.name'] = {$in: ['stprofileuns', 'stprofile']};
     }
 
@@ -98,7 +98,7 @@ async function getProfiles(db, dac_config, dacName, accounts, legacy = false) {
     // Calculate member type
     for (let r=0;r<result.results.length;r++){
         const data = result.results[r];
-        data.member_type = await getMemberType(data.account, dacName, db);
+        data.member_type = await getMemberType(data.account, dacId, db);
 
         // console.log(data);
         result.results[r] = data;

--- a/src/profile-helper.js
+++ b/src/profile-helper.js
@@ -10,11 +10,11 @@ const null_profile = {
     url: ""
 };
 
-async function getMemberType(account, dac_id, db){
+async function getMemberType(account, dacName, db){
     let member_type = 0;
 
     const coll = db.collection('memberstats');
-    const res = await coll.findOne({account, dac_id});
+    const res = await coll.findOne({account, dac_id: dacName});
     if (res){
         member_type = res.member_type;
     }
@@ -22,14 +22,14 @@ async function getMemberType(account, dac_id, db){
     return member_type;
 }
 
-async function getProfiles(db, dac_config, dac_id, accounts, legacy = false) {
+async function getProfiles(db, dac_config, dacName, accounts, legacy = false) {
     const collection = db.collection('actions');
     const cust_contract = dac_config.accounts.get(2);
 
-    const query = {"action.account": cust_contract, "action.name": "stprofile", "action.data.dac_id":dac_id, "action.data.cand": {$in: accounts}};
+    const query = {"action.account": cust_contract, "action.name": "stprofile", "action.data.dac_id":dacName, "action.data.cand": {$in: accounts}};
 
     if (legacy){
-        query['action.data.dac_id'] = {$in: [dac_id, null]};
+        query['action.data.dac_id'] = {$in: [dacName, null]};
         query['action.name'] = {$in: ['stprofileuns', 'stprofile']};
     }
 
@@ -98,7 +98,7 @@ async function getProfiles(db, dac_config, dac_id, accounts, legacy = false) {
     // Calculate member type
     for (let r=0;r<result.results.length;r++){
         const data = result.results[r];
-        data.member_type = await getMemberType(data.account, dac_id, db);
+        data.member_type = await getMemberType(data.account, dacName, db);
 
         // console.log(data);
         result.results[r] = data;

--- a/src/schemas/get_profile.js
+++ b/src/schemas/get_profile.js
@@ -8,9 +8,14 @@ const getProfileSchema = {
             "account": {
                 description: 'Account to fetch, you can supply multiple accounts by separating them with a comma',
                 type: 'string'
+            },
+            "dac_name": {
+                description: 'Organization name',
+                type: 'string'
             }
         },
-        required: ['account']
+        required: ['account'],
+        required: ['dac_name']
     },
     response: {
         200: {

--- a/src/schemas/get_profile.js
+++ b/src/schemas/get_profile.js
@@ -9,13 +9,13 @@ const getProfileSchema = {
                 description: 'Account to fetch, you can supply multiple accounts by separating them with a comma',
                 type: 'string'
             },
-            "dac_name": {
+            "dac_id": {
                 description: 'Organization name',
                 type: 'string'
             }
         },
         required: ['account'],
-        required: ['dac_name']
+        required: ['dac_id']
     },
     response: {
         200: {


### PR DESCRIPTION
The purpose of this PR is to replace custom header `X-DAC-Name` with regular query param `dac_name` in the `/profile` request

```
// before
curl -X GET "http://127.0.0.1:41629/v1/eosdac/profile?account=1x2qw.wam" -H  "accept: application/json" -H "X-DAC-Name: nerix"

// current
curl -X GET "http://127.0.0.1:41629/v1/eosdac/profile?account=1x2qw.wam&dac_name=nerix"
```
