### PR TITLE
set dacId as request param

### DIFF
--- a/src/api-handlers/getProfile.js
+++ b/src/api-handlers/getProfile.js
@@ -1,12 +1,13 @@
 const {getProfileSchema} = require('../schemas');
 const {NotFound} = require('http-errors');
 const {getProfiles} = require('../profile-helper.js');
-const { loadConfig, loadDacConfig } = require('../functions');
+const { loadDacConfig } = require('../functions');
 
 async function getProfile(fastify, request) {
-    const config = loadConfig();
-    const { account, dac_id } = request.query;
-    const dacId = dac_id || config.eos.legacyDacs[0];
+    const {
+        query: { account },
+        params: { dacId },
+    } = request;
     const accounts = account.split(',');
     const dacConfig = await loadDacConfig(fastify, dacId);
 
@@ -27,7 +28,7 @@ async function getProfile(fastify, request) {
 
 
 module.exports = function (fastify, opts, next) {
-    fastify.get('/profile', {
+    fastify.get('/:dacId/profile', {
         schema: getProfileSchema.GET
     }, async (request, reply) => {
         const profile = await getProfile(fastify, request);

--- a/src/schemas/get_profile.js
+++ b/src/schemas/get_profile.js
@@ -2,6 +2,16 @@ const getProfileSchema = {
     description: 'Get user profile',
     summary: 'Fetches the user profile for a member',
     tags: ['v1'],
+    params: {
+        type: 'object',
+        required: [ 'dacId' ],
+        properties: {
+            dacId: {
+                type: 'string',
+                description: 'Organization name',
+            }
+        }
+    },
     querystring: {
         type: 'object',
         properties: {
@@ -9,13 +19,8 @@ const getProfileSchema = {
                 description: 'Account to fetch, you can supply multiple accounts by separating them with a comma',
                 type: 'string'
             },
-            "dac_id": {
-                description: 'Organization name',
-                type: 'string'
-            }
         },
         required: ['account'],
-        required: ['dac_id']
     },
     response: {
         200: {


### PR DESCRIPTION
The purpose of this PR is to use request param dacId in the /profile route
```
/v1/eosdac/:dacId/profile?account=

// before
curl GET "http://127.0.0.1:41629/v1/eosdac/profile?account=foo&dac_id=nerix"

// current
curl GET "http://127.0.0.1:41629/v1/eosdac/nerix/profile?account=foo,bar,baz"
```